### PR TITLE
Fix default route metrics labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $ gem install fluent-plugin-label-router
 ### Specific install
 
 ```
-$ gem install specific_install && gem specific_install -l https://github.com/banzaicloud/fluent-plugin-label-router.git
+$ gem install specific_install && gem specific_install -l https://github.com/banzaicloud/fluent-plugin-label-router.git
 ```
 
 ### Bundler
@@ -114,7 +114,7 @@ Configuration to re-tag and re-label all logs from `default` namespace with labe
 ```
 
 ### 2. Exclude specific `labels` and `namespaces`
-Configuration to re-tag and re-label all logs that **not** from `default` namespace **and not** have labels `ap=nginx` and `env=dev`
+Configuration to re-tag and re-label all logs that **not** from `default` namespace **and not** have labels `app=nginx` and `env=dev`
 ```
 <match example.tag**>
   @type label_router

--- a/lib/fluent/plugin/out_label_router.rb
+++ b/lib/fluent/plugin/out_label_router.rb
@@ -33,6 +33,8 @@ module Fluent
       config_param :sticky_tags, :bool, default: true
       desc "Default label to drain unmatched patterns"
       config_param :default_route, :string, :default => ""
+      desc "Metrics labels for the default_route"
+      config_param :default_metrics_labels, :hash, :default => {}
       desc "Default tag to drain unmatched patterns"
       config_param :default_tag, :string, :default => ""
       desc "Enable metrics for the router"
@@ -72,15 +74,18 @@ module Fluent
               if registry.exist?(:fluentd_router_records_total)
                 @counter = registry.get(:fluentd_router_records_total)
               else
-                @counter = registry.counter(:fluentd_router_records_total, docstring: "Total number of events router for the flow", labels: [:flow, :id])
+                @counter = registry.counter(:fluentd_router_records_total, docstring: "Total number of events routed for the flow", labels: [:flow, :id])
               end
           end
         end
 
         def get_labels
-          default = { 'flow': @label }
-          labels = default.merge(@metrics_labels)
-          labels
+          labels = { 'flow': @label, 'id': "default" }
+          if !@metrics_labels.nil?
+            labels.merge(@metrics_labels)
+          else
+            labels
+          end
         end
 
         # Evaluate selectors
@@ -211,7 +216,7 @@ module Fluent
         end
 
         if @default_route != '' or @default_tag != ''
-          default_rule = { 'matches' => nil, 'tag' => @default_tag, '@label' => @default_route}
+          default_rule = { 'matches' => nil, 'tag' => @default_tag, '@label' => @default_route, 'metrics_labels' => @default_metrics_labels }
           @default_router = Route.new(default_rule, event_emitter_router(@default_route), @registry)
         end
 

--- a/lib/fluent/plugin/out_label_router.rb
+++ b/lib/fluent/plugin/out_label_router.rb
@@ -81,11 +81,7 @@ module Fluent
 
         def get_labels
           labels = { 'flow': @label, 'id': "default" }
-          if !@metrics_labels.nil?
-            labels.merge(@metrics_labels)
-          else
-            labels
-          end
+          !@metrics_labels.nil? ? labels.merge(@metrics_labels) : labels
         end
 
         # Evaluate selectors


### PR DESCRIPTION
Provide a separate configuration option for the default route's metrics labels, and fix nil derefence in case it's not available.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New feature?    | no
| API breaks?     | no
| Deprecations?   | no
| Related tickets | fixes #16 
| License         | Apache 2.0


### What's in this PR?
Fix the nil dereference and add  missing support for metrics labels for the default route.
