### PR TITLE
Improve route matching performance

### DIFF
--- a/lib/fluent/plugin/out_label_router.rb
+++ b/lib/fluent/plugin/out_label_router.rb
@@ -96,11 +96,8 @@ module Fluent
         # There is no match at all                 -> return false
         def match?(metadata)
           @matches.each do |match|
-            if filter_select(match, metadata) and !match.negate
-              return true
-            end
-            if filter_select(match, metadata) and match.negate
-              return false
+            if filter_select(match, metadata)
+              return !match.negate
             end
           end
           false


### PR DESCRIPTION
This change not only saves some lines, but avoids calling filter_select twice with the same arguments if there is no match.