### PR TITLE
Allow regex in namespaces values

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ $ bundle
 The configuration builds from `<route>` sections. Each `route` section
 can have several `<match>` statement. These statements computed in order and
 positive (or in case of *negate true* negative) results break the evaluation.
-We can say that the sections are coupled in a **lazy evaluation OR**. 
+We can say that the sections are coupled in a **lazy evaluation OR**.
 
 ```
 <match example.tag**>
@@ -77,7 +77,8 @@ Configuration reference
 | Parameter        | Description                                                                                           | Type     | Default  |
 |------------------|-------------------------------------------------------------------------------------------------------|----------|----------|
 | labels           | Label definition to match record. Example: `app:nginx`                                                | Hash     | nil      |
-| namespaces       | Comma separated list of namespaces (list value can be a regex). Ignored if left empty.                                            | []string | nil      |
+| namespaces       | Comma separated list of namespaces. Ignored if left empty.                                            | []string | nil      |
+| namespaces_regex | Comma separated list of regex for namespaces match. Ignored if left empty.                            | []string | nil      |
 | namespace_labels | Label definition of the namespace a record originates. Example: `kubernetes.io/metadata.name=default` | Hash     | nil      |
 | hosts            | Comma separated list of hosts. Ignored if left empty.                                                 | []string | nil      |
 | container_names  | Comma separated list of container names. Ignored if left empty.                                       | []string | nil      |
@@ -183,7 +184,7 @@ Rewrite all
 </match>
 ```
 
-### 4. One of `@label` ot `tag` configuration should be specified
+### 4. One of `@label` or `tag` configuration should be specified
 If you don't rewrite either of them fluent will **likely to crash** because it will reprocess the same messages again.
 
 ### 5. Default route/tag
@@ -200,9 +201,9 @@ Use `default_label` and/or `default_tag` to route non matching records.
 </match>
 ```
 
-### 5. Use regex in namespaces
+### 6. Use of namespaces_regex
 
-Configuration to re-tag and re-label all logs from namespaces which match regex .*-system$
+Configuration to re-tag and re-label all logs from namespaces_regex which match regex .*-system$
 
 ```
 <match example.tag**>
@@ -211,7 +212,7 @@ Configuration to re-tag and re-label all logs from namespaces which match regex 
     @label SYSTEM_NAMESPACE
     tag new_tag
     <match>
-      namespaces .*-system$
+      namespaces_regex .*-system$
     </match>
   </route>
 </match>

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Configuration reference
 | Parameter        | Description                                                                                           | Type     | Default  |
 |------------------|-------------------------------------------------------------------------------------------------------|----------|----------|
 | labels           | Label definition to match record. Example: `app:nginx`                                                | Hash     | nil      |
-| namespaces       | Comma separated list of namespaces. Ignored if left empty.                                            | []string | nil      |
+| namespaces       | Comma separated list of namespaces (list value can be a regex). Ignored if left empty.                                            | []string | nil      |
 | namespace_labels | Label definition of the namespace a record originates. Example: `kubernetes.io/metadata.name=default` | Hash     | nil      |
 | hosts            | Comma separated list of hosts. Ignored if left empty.                                                 | []string | nil      |
 | container_names  | Comma separated list of container names. Ignored if left empty.                                       | []string | nil      |
@@ -145,7 +145,7 @@ Output
 @label = "@NGINX"; tag = "new_tag"; {"log" => "", "kubernetes" => { "namespace_name" => "default", "labels" =>  {"app" => "nginx" } } }
 nil
 ```
-### 2. Both `labels` and `namespace` are optional
+### 3. Both `labels` and `namespace` are optional
 Only `labels`
 ```
 <match example.tag**>
@@ -183,10 +183,10 @@ Rewrite all
 </match>
 ```
 
-### 3. One of `@label` ot `tag` configuration should be specified
+### 4. One of `@label` ot `tag` configuration should be specified
 If you don't rewrite either of them fluent will **likely to crash** because it will reprocess the same messages again.
 
-### 4. Default route/tag
+### 5. Default route/tag
 
 Use `default_label` and/or `default_tag` to route non matching records.
 
@@ -200,6 +200,22 @@ Use `default_label` and/or `default_tag` to route non matching records.
 </match>
 ```
 
+### 5. Use regex in namespaces
+
+Configuration to re-tag and re-label all logs from namespaces which match regex .*-system$
+
+```
+<match example.tag**>
+  @type label_router
+  <route>
+    @label SYSTEM_NAMESPACE
+    tag new_tag
+    <match>
+      namespaces .*-system$
+    </match>
+  </route>
+</match>
+```
 
 ## Copyright
 

--- a/lib/fluent/plugin/out_label_router.rb
+++ b/lib/fluent/plugin/out_label_router.rb
@@ -113,8 +113,8 @@ module Fluent
           unless match.container_names.empty? || match.container_names.include?(metadata[:container])
             return false
           end
-          # Break if list of namespaces is not empty and does not include actual namespace
-          unless match.namespaces.empty? || match.namespaces.include?(metadata[:namespace])
+          # Break if list of namespaces is not empty and does not containe any entry that match actual namespace
+          unless match.namespaces.empty? || match.namespaces.any? { |pattern| Regexp.new(pattern).match?(metadata[:namespace]) }
             return false
           end
           # Break if list of namespace_labels is not empty and does not match actual namespace labels

--- a/lib/fluent/plugin/out_label_router.rb
+++ b/lib/fluent/plugin/out_label_router.rb
@@ -54,6 +54,8 @@ module Fluent
           config_param :labels, :hash, :default => {}
           desc "List of namespace definition to filter the record. Ignored if left empty."
           config_param :namespaces, :array, :default => [], value_type: :string
+          desc "List of regex for namespace definition to filter the record. Ignored if left empty."
+          config_param :namespaces_regex, :array, :default => [], value_type: :string
           desc "List of namespace labels to filter the record based on where it came from. Ignored if left empty."
           config_param :namespace_labels, :hash, :default => {}
           desc "List of hosts definition to filter the record. Ignored if left empty."
@@ -113,8 +115,12 @@ module Fluent
           unless match.container_names.empty? || match.container_names.include?(metadata[:container])
             return false
           end
-          # Break if list of namespaces is not empty and does not containe any entry that match actual namespace
-          unless match.namespaces.empty? || match.namespaces.any? { |pattern| Regexp.new(pattern).match?(metadata[:namespace]) }
+          # Break if list of namespaces is not empty and does not include actual namespace
+          unless match.namespaces.empty? || match.namespaces.include?(metadata[:namespace])
+            return false
+          end
+          # Break if list of namespaces is not empty and does not contain any entry that match actual namespace
+          unless match.namespaces_regex.empty? || match.namespaces_regex.any? { |pattern| Regexp.new(pattern).match?(metadata[:namespace]) }
             return false
           end
           # Break if list of namespace_labels is not empty and does not match actual namespace labels

--- a/test/plugin/test_out_label_router.rb
+++ b/test/plugin/test_out_label_router.rb
@@ -62,7 +62,7 @@ class LabelRouterOutputTest < Test::Unit::TestCase
 <route>
   <match>
     labels app:app3
-    namespaces .*-system$,^kube-.*
+    namespaces_regex .*-system$,^kube-.*
   </match>
 </route>
 <route>
@@ -249,6 +249,7 @@ default_tag "new_tag"
   <match>
     labels
     namespaces
+    namespaces_regex
   </match>
 </route>
 ]
@@ -279,6 +280,7 @@ default_tag "new_tag"
     <match>
       labels
       namespaces
+      namespaces_regex
     </match>
   </route>
   ]

--- a/test/plugin/test_out_label_router.rb
+++ b/test/plugin/test_out_label_router.rb
@@ -61,6 +61,12 @@ class LabelRouterOutputTest < Test::Unit::TestCase
 </route>
 <route>
   <match>
+    labels app:app3
+    namespaces .*-system$,^kube-.*
+  </match>
+</route>
+<route>
+  <match>
     labels app:nginx
     namespaces dev,sandbox
   </match>
@@ -98,23 +104,42 @@ class LabelRouterOutputTest < Test::Unit::TestCase
       assert_equal(false, r2.match?(labels: { 'app3' => 'app' }, namespace: 'system'))
 
       r3 = Fluent::Plugin::LabelRouterOutput::Route.new(d.instance.routes[2], nil,nil)
-      assert_equal(true, r3.match?(labels: { 'app' => 'nginx' }, namespace: 'dev'))
-      assert_equal(true, r3.match?(labels: { 'app' => 'nginx' }, namespace: 'sandbox'))
-      assert_equal(false, r3.match?(labels: { 'app' => 'nginx2' }, namespace: 'sandbox'))
+      # Match selector and namespace: GO
+      assert_equal(true, r3.match?(labels: { 'app' => 'app3' }, namespace: 'logging-system'))
+      # Nothing matched: NO GO
+      assert_equal(false, r3.match?(labels: { 'app' => 'app3' }, namespace: 'logging-system1'))
+      # Nothing matched: NO GO
+      assert_equal(false, r3.match?(labels: { 'app' => 'app3' }, namespace: 'system'))
+      # Nothing matched: NO GO
+      assert_equal(false, r3.match?(labels: { 'app' => 'app3' }, namespace: '1system'))
+      # Match selector and namespace: GO
+      assert_equal(true, r3.match?(labels: { 'app' => 'app3' }, namespace: 'kube-ns'))
+      # Nothing matched: NO GO
+      assert_equal(false, r3.match?(labels: { 'app' => 'app3' }, namespace: '1kube-ns'))
+      # Nothing matched: NO GO
+      assert_equal(false, r3.match?(labels: { 'app' => 'app3' }, namespace: 'kube'))
+      # Nothing matched: NO GO
+      assert_equal(false, r3.match?(labels: { 'app' => 'app3' }, namespace: 'kube1'))
+
 
       r4 = Fluent::Plugin::LabelRouterOutput::Route.new(d.instance.routes[3], nil,nil)
-      # Matching container name
-      assert_equal(true, r4.match?(labels: { 'app' => 'nginx' }, namespace: 'dev', container: 'mycontainer'))
-      # Missing container name is equal to wrong container
-      assert_equal(false, r4.match?(labels: { 'app' => 'nginx' }, namespace: 'sandbox'))
-      # Wrong container name
-      assert_equal(false, r4.match?(labels: { 'app' => 'nginx' }, namespace: 'dev', container: 'mycontainer2'))
-      # Wrong label but good namespace and container_name
-      assert_equal(false, r4.match?(labels: { 'app' => 'nginx2' }, namespace: 'sandbox',  container_name: 'mycontainer2'))
+      assert_equal(true, r4.match?(labels: { 'app' => 'nginx' }, namespace: 'dev'))
+      assert_equal(true, r4.match?(labels: { 'app' => 'nginx' }, namespace: 'sandbox'))
+      assert_equal(false, r4.match?(labels: { 'app' => 'nginx2' }, namespace: 'sandbox'))
 
-      r4 = Fluent::Plugin::LabelRouterOutput::Route.new(d.instance.routes[4], nil,nil)
+      r5 = Fluent::Plugin::LabelRouterOutput::Route.new(d.instance.routes[4], nil,nil)
+      # Matching container name
+      assert_equal(true, r5.match?(labels: { 'app' => 'nginx' }, namespace: 'dev', container: 'mycontainer'))
+      # Missing container name is equal to wrong container
+      assert_equal(false, r5.match?(labels: { 'app' => 'nginx' }, namespace: 'sandbox'))
+      # Wrong container name
+      assert_equal(false, r5.match?(labels: { 'app' => 'nginx' }, namespace: 'dev', container: 'mycontainer2'))
+      # Wrong label but good namespace and container_name
+      assert_equal(false, r5.match?(labels: { 'app' => 'nginx2' }, namespace: 'sandbox',  container_name: 'mycontainer2'))
+
+      r6 = Fluent::Plugin::LabelRouterOutput::Route.new(d.instance.routes[5], nil,nil)
       # Matching namespaces_labels
-      assert_equal(true, r4.match?(namespaces_labels: { 'name' => 'default' }))
+      assert_equal(true, r6.match?(namespaces_labels: { 'name' => 'default' }))
     end
   end
 


### PR DESCRIPTION
Fix https://github.com/kube-logging/fluent-plugin-label-router/issues/28

rake test working
```
Finished in 0.037736777 seconds.
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
7 tests, 35 assertions, 0 failures, 0 errors, 0 pendings, 0 omissions, 0 notifications
100% passed
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------
185.50 tests/s, 927.48 assertions/s
```
